### PR TITLE
add router

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -2,6 +2,7 @@ import { serve, ServeInit } from "https://deno.land/std@0.163.0/http/server.ts";
 import { Context } from "./context.ts";
 import decode from "./decode.ts";
 import { Handler, ServerError } from "./types.ts";
+import { Router } from "./router.ts";
 
 const notFound = {
   status: 404,
@@ -85,6 +86,13 @@ export class WebApp {
       const err = ServerError.from(error);
       const res = err.serialize();
       return decode(res, err.status);
+    }
+  };
+
+  use = (path: string, router: Router) => {
+    for (const [id, handler] of router.routes) {
+      const [method, pathname] = id.split(",");
+      this.#add(path + pathname, method, handler);
     }
   };
 

--- a/mod.ts
+++ b/mod.ts
@@ -2,3 +2,4 @@ import { WebApp } from "./app.ts";
 export default () => new WebApp();
 export { Context } from "./context.ts";
 export type { Handler } from "./types.ts";
+export { Router } from "./router.ts";

--- a/router.ts
+++ b/router.ts
@@ -1,0 +1,25 @@
+import { WebApp } from "./app.ts";
+import { Handler } from "./types.ts";
+
+export class Router extends WebApp {
+  routes: Map<string, Handler>;
+
+  constructor() {
+    super();
+    this.routes = new Map();
+
+    // deno-fmt-ignore-line
+    const methods = ['get', 'post', 'put', 'patch', 'delete', 'options', 'head'] as const;
+    for (const method of methods) {
+      this[method] = (path, handler) =>
+        this.#add(path, method.toUpperCase(), handler);
+    }
+  }
+
+  #add(pathname: string, method: string, handler: Handler) {
+    const id = method + ',' + pathname;
+    this.routes.set(id, handler);
+
+    return this;
+  }
+}

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "https://deno.land/std@0.161.0/testing/asserts.ts";
 import fast, { Context } from "./mod.ts";
+import { Router } from "./router.ts";
 
 function makeRequest(path: string, init: RequestInit = {}) {
   path = "https://example.com" + path;
@@ -7,6 +8,7 @@ function makeRequest(path: string, init: RequestInit = {}) {
 }
 
 const app = fast();
+const router = new Router();
 
 Deno.test("404", async () => {
   const req = makeRequest("/404");
@@ -129,4 +131,15 @@ Deno.test("decode", async () => {
   const req5 = makeRequest("/res");
   const res5 = await app.handle(req5);
   assertEquals(res5.status, 201);
+});
+
+router.get("/", () => "router home");
+app.use("/api", router);
+
+Deno.test("router", async () => {
+  const req = makeRequest("/api/");
+  const res = await app.handle(req);
+  const data = await res.text();
+  assertEquals(res.status, 200);
+  assertEquals(data, "router home");
 });


### PR DESCRIPTION
This PR adds a simple router, which can be used this way:

```ts
const api_v1 = new Router()
api_v1.get('/', () => 'API V1')

app.use('/api/v1', api_v1)
```